### PR TITLE
Fix storybook webpack config to take scss modules into account

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,61 @@
-const path = require('path');
+const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
+const postcssNormalize = require('postcss-normalize');
+
+const sassRegex = /\.(scss|sass)$/;
+const sassModuleRegex = /\.module\.(scss|sass)$/;
+
+// common function to get style loaders
+const getStyleLoaders = (cssOptions, preProcessor) => {
+  const loaders = [
+    require.resolve('style-loader'),
+    {
+      loader: require.resolve('css-loader'),
+      options: cssOptions
+    },
+    {
+      // Options for PostCSS as we reference these options twice
+      // Adds vendor prefixing based on your specified browser support in
+      // package.json
+      loader: require.resolve('postcss-loader'),
+      options: {
+        // Necessary for external CSS imports to work
+        // https://github.com/facebook/create-react-app/issues/2677
+        ident: 'postcss',
+        plugins: () => [
+          require('postcss-flexbugs-fixes'),
+          require('postcss-preset-env')({
+            autoprefixer: {
+              flexbox: 'no-2009'
+            },
+            stage: 3
+          }),
+          // Adds PostCSS Normalize as the reset css with default options,
+          // so that it honors browserslist config in package.json
+          // which in turn let's users customize the target behavior as per their needs.
+          postcssNormalize()
+        ],
+        sourceMap: true
+      }
+    }
+  ].filter(Boolean);
+  if (preProcessor) {
+    loaders.push(
+      {
+        loader: require.resolve('resolve-url-loader'),
+        options: {
+          sourceMap: true
+        }
+      },
+      {
+        loader: require.resolve(preProcessor),
+        options: {
+          sourceMap: true
+        }
+      }
+    );
+  }
+  return loaders;
+};
 
 module.exports = ({ config }) => {
   config.module.rules.push({
@@ -9,9 +66,34 @@ module.exports = ({ config }) => {
     }
   });
   config.module.rules.push({
-    test: /\.scss$/,
-    use: ['style-loader', 'css-loader', 'sass-loader'],
-    include: path.resolve(__dirname, '../')
+    test: sassRegex,
+    exclude: sassModuleRegex,
+    use: getStyleLoaders(
+      {
+        importLoaders: 2,
+        sourceMap: false
+      },
+      'sass-loader',
+      'postcss-loader'
+    ),
+    // Don't consider CSS imports dead code even if the
+    // containing package claims to have no side effects.
+    // Remove this when webpack adds a warning or an error for this.
+    // See https://github.com/webpack/webpack/issues/6571
+    sideEffects: true
+  });
+  config.module.rules.push({
+    test: sassModuleRegex,
+    use: getStyleLoaders(
+      {
+        importLoaders: 2,
+        sourceMap: true,
+        modules: {
+          getLocalIdent: getCSSModuleLocalIdent
+        }
+      },
+      'sass-loader'
+    )
   });
   config.resolve.extensions.push('.ts', '.tsx');
   return config;


### PR DESCRIPTION
Code mostly copied from the ejected configuration of CRA as
storybook attempts to inherit from CRA's webpack config if
it is present.